### PR TITLE
adding basic auth

### DIFF
--- a/src/Authentication/Configurations/AuthenticationOptions.cs
+++ b/src/Authentication/Configurations/AuthenticationOptions.cs
@@ -30,6 +30,9 @@ namespace Monai.Deploy.Security.Authentication.Configurations
         [ConfigurationKeyName("openId")]
         public OpenIdOptions? OpenId { get; set; }
 
+        [ConfigurationKeyName("basicAuth")]
+        public BasicAuthOptions? BasicAuth { get; set; }
+
         public bool BypassAuth(ILogger logger)
         {
             Guard.Against.Null(logger);
@@ -38,6 +41,11 @@ namespace Monai.Deploy.Security.Authentication.Configurations
             {
                 logger.BypassAuthentication();
                 return true;
+            }
+
+            if (BasicAuthEnabled(logger))
+            {
+                return false;
             }
 
             if (OpenId is null)
@@ -64,6 +72,15 @@ namespace Monai.Deploy.Security.Authentication.Configurations
             ValidateClaims(OpenId.Claims.UserClaims!, true);
             ValidateClaims(OpenId.Claims.AdminClaims!, false);
 
+            return false;
+        }
+
+        public bool BasicAuthEnabled(ILogger logger)
+        {
+            if (BasicAuth is not null && BasicAuth.Id is not null && BasicAuth.Password is not null)
+            {
+                return true;
+            }
             return false;
         }
 

--- a/src/Authentication/Configurations/BasicAuthOptions.cs
+++ b/src/Authentication/Configurations/BasicAuthOptions.cs
@@ -1,4 +1,18 @@
-﻿
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.Extensions.Configuration;
 

--- a/src/Authentication/Configurations/BasicAuthOptions.cs
+++ b/src/Authentication/Configurations/BasicAuthOptions.cs
@@ -1,0 +1,15 @@
+﻿
+
+using Microsoft.Extensions.Configuration;
+
+namespace Monai.Deploy.Security.Authentication.Configurations
+{
+    public class BasicAuthOptions
+    {
+        [ConfigurationKeyName("userName")]
+        public string? Id { get; set; }
+
+        [ConfigurationKeyName("password")]
+        public string? Password { get; set; }
+    }
+}

--- a/src/Authentication/Extensions/AuthKeys.cs
+++ b/src/Authentication/Extensions/AuthKeys.cs
@@ -25,5 +25,6 @@ namespace Monai.Deploy.Security.Authentication.Extensions
 
         // Configuration Keys
         public const string OpenId = "OpenId";
+        public const string BasicAuth = "BasicAuth";
     }
 }

--- a/src/Authentication/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Authentication/Extensions/IApplicationBuilderExtensions.cs
@@ -27,7 +27,9 @@ namespace Monai.Deploy.Security.Authentication.Extensions
         public static IApplicationBuilder UseEndpointAuthorizationMiddleware(
             this IApplicationBuilder builder)
         {
-            return builder.UseMiddleware<EndpointAuthorizationMiddleware>();
+            builder.UseMiddleware<BasicAuthorizationMiddleware>();
+            builder.UseMiddleware<EndpointAuthorizationMiddleware>();
+            return builder;
         }
     }
 }

--- a/src/Authentication/Middleware/BasicAuthorizationMiddleware.cs
+++ b/src/Authentication/Middleware/BasicAuthorizationMiddleware.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * Copyright 2022 MONAI Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Monai.Deploy.Security.Authentication.Configurations;
+
+namespace Monai.Deploy.Security.Authentication.Middleware
+{
+    /// <summary>
+    /// EndpointAuthorizationMiddleware for checking endpoint configuration.
+    /// </summary>
+    public class BasicAuthorizationMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IOptions<AuthenticationOptions> _options;
+        private readonly ILogger<BasicAuthorizationMiddleware> _logger;
+
+        public BasicAuthorizationMiddleware(
+            RequestDelegate next,
+            IOptions<AuthenticationOptions> options,
+            ILogger<BasicAuthorizationMiddleware> logger)
+        {
+            _next = next;
+            _options = options;
+            _logger = logger;
+        }
+
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+
+            if (_options.Value.BasicAuthEnabled(_logger) is false)
+            {
+                await _next(httpContext).ConfigureAwait(false);
+                return;
+            }
+            try
+            {
+                var authHeader = AuthenticationHeaderValue.Parse(httpContext.Request.Headers["Authorization"]);
+                var credentialBytes = Convert.FromBase64String(authHeader.Parameter);
+                var credentials = Encoding.UTF8.GetString(credentialBytes).Split(':', 2);
+                var username = credentials[0];
+                var password = credentials[1];
+                if (string.Compare(username, _options.Value.BasicAuth.Id, false) is 0 &&
+                    string.Compare(password, _options.Value.BasicAuth.Password, false) is 0)
+                {
+                    var claims = new[] { new Claim("name", credentials[0]) };
+                    var identity = new ClaimsIdentity(claims, "Basic");
+                    var claimsPrincipal = new ClaimsPrincipal(identity);
+                    httpContext.User = claimsPrincipal;
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception ");
+            }
+            httpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+
+        }
+    }
+}

--- a/src/Authentication/Middleware/EndpointAuthorizationMiddleware.cs
+++ b/src/Authentication/Middleware/EndpointAuthorizationMiddleware.cs
@@ -48,6 +48,11 @@ namespace Monai.Deploy.Security.Authentication.Middleware
                 await _next(httpContext).ConfigureAwait(false);
                 return;
             }
+            if (_options.Value.BasicAuthEnabled(_logger))
+            {
+                await _next(httpContext).ConfigureAwait(false);
+                return;
+            }
 
             if (httpContext.User is not null
                 && httpContext.User.Identity is not null

--- a/src/Authentication/Tests/EndpointAuthorizationMiddlewareTest.cs
+++ b/src/Authentication/Tests/EndpointAuthorizationMiddlewareTest.cs
@@ -15,6 +15,7 @@
  */
 
 using System.Net;
+using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -133,6 +134,36 @@ namespace Monai.Deploy.Security.Authentication.Tests
             var responseMessage = await client.GetAsync("api/Test").ConfigureAwait(false);
 
             Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
+        }
+
+
+        [Fact]
+        public async Task GivenConfigurationFileWithBasicConfigured_WhenUserIsNotAuthenticated_ExpectToDenyRequest()
+        {
+            using var host = await new HostBuilder().ConfigureWebHost(SetupWebServer("test.basic.json")).StartAsync().ConfigureAwait(false);
+
+            var server = host.GetTestServer();
+            server.BaseAddress = new Uri("https://example.com/");
+
+            var client = server.CreateClient();
+            var responseMessage = await client.GetAsync("api/Test").ConfigureAwait(false);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, responseMessage.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenConfigurationFileWithBasicConfigured_WhenUserIsAuthenticated_ExpectToDenyRequest()
+        {
+            using var host = await new HostBuilder().ConfigureWebHost(SetupWebServer("test.basic.json")).StartAsync().ConfigureAwait(false);
+
+            var server = host.GetTestServer();
+            server.BaseAddress = new Uri("https://example.com/");
+
+            var client = server.CreateClient();
+            client.DefaultRequestHeaders.Add("Authorization", $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes("user:pass"))}");
+            var responseMessage = await client.GetAsync("api/Test").ConfigureAwait(false);
+
+            Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
         }
 
         private static Action<IWebHostBuilder> SetupWebServer(string configFile) => webBuilder =>

--- a/src/Authentication/Tests/test.auth-noclientid.json
+++ b/src/Authentication/Tests/test.auth-noclientid.json
@@ -1,6 +1,9 @@
 ﻿{
   "MonaiDeployAuthentication": {
     "bypassAuthentication": false,
+    "basicAuth": {
+      "userName": "nopassword"
+    },
     "openId": {
       "realm": "TEST-REALM",
       "realmKey": "l9ZRlbMQBt9k1klUUrlWFuke8WbqnEde",

--- a/src/Authentication/Tests/test.basic.json
+++ b/src/Authentication/Tests/test.basic.json
@@ -1,0 +1,9 @@
+﻿{
+  "MonaiDeployAuthentication": {
+    "BypassAuthentication": false,
+    "basicAuth": {
+      "userName": "user",
+      "password":  "pass"
+    }
+  }
+}

--- a/src/Authentication/Tests/test.bypassedbybasic.json
+++ b/src/Authentication/Tests/test.bypassedbybasic.json
@@ -1,0 +1,16 @@
+﻿{
+  "MonaiDeployAuthentication": {
+    "BypassAuthentication": false,
+    "basicAuth": {
+      "userName": "nopassword",
+      "password":  "sded"
+    },
+    "openId": {
+      "realm": "TEST-REALM",
+      "realmKey": "l9ZRlbMQBt9k1klUUrlWFuke8WbqnEde",
+      "audiences": [ "monai-app" ],
+      "roleClaimType": "roles",
+      "clientId": "monai-app-test"
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Neil South <neil.south@answerdigital.com>

### Description

adding a way we can use simple API keys for internal authorization

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
